### PR TITLE
Moved initialization of nMaxConnections to appropriate section

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -56,6 +56,7 @@ bool fConfChange;
 unsigned int nNodeLifespan;
 unsigned int nDerivationMethodIndex;
 unsigned int nMinerSleep;
+int nMaxConnections;
 bool fUseFastIndex;
 bool fOnlyTor = false;
 
@@ -372,6 +373,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     nNodeLifespan = GetArg("-addrlifespan", 7);
     fUseFastIndex = GetBoolArg("-fastindex", true);
     nMinerSleep = GetArg("-minersleep", 500);
+    nMaxConnections = GetArg("-maxconnections", 125);
 
     nDerivationMethodIndex = 0;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -56,7 +56,6 @@ uint64_t nLocalHostNonce = 0;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 std::string strSubVersion;
-int nMaxConnections = GetArg("-maxconnections", 125);
 
 vector<CNode*> vNodes;
 CCriticalSection cs_vNodes;


### PR DESCRIPTION
Earlier version had a fixed value. 
Ideally, Bitcoin's improvements (such as available inode checks) are also integrated.