### PR TITLE
Removed the ranking code to circumvent the cpu hug.

### DIFF
--- a/src/qt/forms/masternodemanager.ui
+++ b/src/qt/forms/masternodemanager.ui
@@ -65,11 +65,6 @@
            </column>
            <column>
             <property name="text">
-             <string>Rank</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
              <string>Active</string>
             </property>
            </column>

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -128,8 +128,6 @@ void MasternodeManager::updateNodeList()
         // Address, Rank, Active, Active Seconds, Last Seen, Pub Key
         QTableWidgetItem *activeItem = new QTableWidgetItem(QString::number(mn.IsEnabled()));
         QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn.addr.ToString()));
-        QString Rank = QString::number(mnodeman.GetMasternodeRank(mn.vin, pindexBest->nHeight));
-        QTableWidgetItem *rankItem = new QTableWidgetItem(Rank.rightJustified(2, '0', false));
         QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(seconds_to_DHMS((qint64)(mn.lastTimeSeen - mn.sigTime)));
         QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat(mn.lastTimeSeen)));
 
@@ -141,11 +139,10 @@ void MasternodeManager::updateNodeList()
         QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(address2.ToString()));
 
         ui->tableWidget->setItem(mnRow, 0, addressItem);
-        ui->tableWidget->setItem(mnRow, 1, rankItem);
-        ui->tableWidget->setItem(mnRow, 2, activeItem);
-        ui->tableWidget->setItem(mnRow, 3, activeSecondsItem);
-        ui->tableWidget->setItem(mnRow, 4, lastSeenItem);
-        ui->tableWidget->setItem(mnRow, 5, pubkeyItem);
+        ui->tableWidget->setItem(mnRow, 1, activeItem);
+        ui->tableWidget->setItem(mnRow, 2, activeSecondsItem);
+        ui->tableWidget->setItem(mnRow, 3, lastSeenItem);
+        ui->tableWidget->setItem(mnRow, 4, pubkeyItem);
     }
 
     ui->countLabel->setText(QString::number(ui->tableWidget->rowCount()));


### PR DESCRIPTION
There is a CPU hog here: QString Rank = QString::number(mnodeman.GetMasternodeRank(mn.vin, pindexBest->nHeight));
The current workaround is to remove the ranking.
(The actual problem is either something too expensive in GetMasternodeRank() or a locking or multi-threading issue in that call.)

Please test the Windows version.