### PR TITLE
Improve error output and masternode status messages

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -37,7 +37,7 @@ void CActiveMasternode::ManageStatus()
             if(!GetLocal(service)) {
                 notCapableReason = "Can't detect external address. Please use the masternodeaddr configuration option.";
                 status = MASTERNODE_NOT_CAPABLE;
-                LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason.c_str());
+                LogPrintf("CActiveMasternode::ManageStatus() %s (%s)\n", getStatusMessage(status), notCapableReason.c_str());
                 return;
             }
         } else {
@@ -478,4 +478,26 @@ bool CActiveMasternode::EnableHotColdMasterNode(CTxIn& newVin, CService& newServ
     LogPrintf("CActiveMasternode::EnableHotColdMasterNode() - Enabled! You may shut down the cold daemon.\n");
 
     return true;
+}
+
+std::string CActiveMasternode::getStatusMessage(){
+    return getStatusMessage(status);    
+}
+    
+std::string CActiveMasternode::getStatusMessage(int status) {
+
+    switch (status){
+        case MASTERNODE_NOT_PROCESSED:      return "Masternode has not been processed."; 
+        case MASTERNODE_IS_CAPABLE:         return "Masternode is a capable masternode and is in running status."; 
+        case MASTERNODE_NOT_CAPABLE:        return "Masternode not capable to be started (" + notCapableReason + ")"; 
+        case MASTERNODE_STOPPED:            return "Masternode is stopped."; 
+        case MASTERNODE_INPUT_TOO_NEW:      return "Masternode not started: input must have at least 15 confirmations."; 
+        case MASTERNODE_PORT_NOT_OPEN:      return "Masternode port is not open."; // This status is currently never used
+        case MASTERNODE_PORT_OPEN:          return "Masternode port is open."; // This status is currently never used
+        case MASTERNODE_SYNC_IN_PROCESS:    return "Masternode Sync in progress. Must wait until sync is complete to start masternode."; 
+        case MASTERNODE_REMOTELY_ENABLED:   return "Masternode is remotely enabled and is in a running status."; 
+        default:
+            break;
+    }
+    return "Unknown status";
 }

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -35,6 +35,7 @@ public:
     CActiveMasternode()
     {        
         status = MASTERNODE_NOT_PROCESSED;
+        notCapableReason = "";
     }
 
     void ManageStatus(); // manage status of main masternode
@@ -62,6 +63,9 @@ public:
 
     // enable hot wallet mode (run a masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);
+    
+    std::string getStatusMessage();
+    std::string getStatusMessage(int status); 
 };
 
 #endif

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -257,6 +257,16 @@ int CommandLineRPC(int argc, char *argv[])
             strPrint = "error: " + write_string(error, false);
             int code = find_value(error.get_obj(), "code").get_int();
             nRet = abs(code);
+
+            if (error.type() != null_type){
+                const Value &errMsg = find_value(error.get_obj(), "message");
+                
+                strPrint = "error code: " +  boost::lexical_cast<std::string>(nRet) + "\n";
+                
+                if (!errMsg.is_null())
+                    strPrint += "error message: " + errMsg.get_str() + "\n";
+            }
+
         }
         else
         {

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -191,10 +191,10 @@ Value masternode(const Array& params, bool fHelp)
         }
         pwalletMain->Lock();
 
-        if(activeMasternode.status == MASTERNODE_STOPPED) return "successfully stopped masternode";
-        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode";
+        if(activeMasternode.status == MASTERNODE_STOPPED) return "Successfully stopped masternode";
+        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "Not a capable masternode";
 
-        return "unknown";
+        return "Unknown";
     }
 
     if (strCommand == "stop-alias")
@@ -354,14 +354,7 @@ Value masternode(const Array& params, bool fHelp)
             pwalletMain->Lock();
         }
 
-        if(activeMasternode.status == MASTERNODE_REMOTELY_ENABLED) return "masternode started remotely";
-        if(activeMasternode.status == MASTERNODE_INPUT_TOO_NEW) return "masternode input must have at least 15 confirmations";
-        if(activeMasternode.status == MASTERNODE_STOPPED) return "masternode is stopped";
-        if(activeMasternode.status == MASTERNODE_IS_CAPABLE) return "successfully started masternode";
-        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode: " + activeMasternode.notCapableReason;
-        if(activeMasternode.status == MASTERNODE_SYNC_IN_PROCESS) return "sync in process. Must wait until client is synced to start.";
-
-        return "unknown";
+        return activeMasternode.getStatusMessage();
     }
 
     if (strCommand == "start-alias")
@@ -482,13 +475,16 @@ Value masternode(const Array& params, bool fHelp)
 
     if (strCommand == "debug")
     {
-        if(activeMasternode.status == MASTERNODE_REMOTELY_ENABLED) return "masternode started remotely";
-        if(activeMasternode.status == MASTERNODE_INPUT_TOO_NEW) return "masternode input must have at least 15 confirmations";
-        if(activeMasternode.status == MASTERNODE_IS_CAPABLE) return "successfully started masternode";
-        if(activeMasternode.status == MASTERNODE_STOPPED) return "masternode is stopped";
-        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode: " + activeMasternode.notCapableReason;
-        if(activeMasternode.status == MASTERNODE_SYNC_IN_PROCESS) return "sync in process. Must wait until client is synced to start.";
-
+        switch (activeMasternode.status){
+            case MASTERNODE_REMOTELY_ENABLED:
+            case MASTERNODE_INPUT_TOO_NEW:
+            case MASTERNODE_IS_CAPABLE:
+            case MASTERNODE_STOPPED:
+            case MASTERNODE_SYNC_IN_PROCESS:
+            case MASTERNODE_NOT_CAPABLE:
+                return activeMasternode.getStatusMessage();               
+        }
+        
         CTxIn vin = CTxIn();
         CPubKey pubkey = CScript();
         CKey key;
@@ -747,8 +743,8 @@ Value masternode(const Array& params, bool fHelp)
         mnObj.push_back(Pair("vin", activeMasternode.vin.ToString().c_str()));
         mnObj.push_back(Pair("service", activeMasternode.service.ToString().c_str()));
         mnObj.push_back(Pair("status", activeMasternode.status));
+        mnObj.push_back(Pair("statusMessage", activeMasternode.getStatusMessage()));
         mnObj.push_back(Pair("pubKeyMasternode", address2.ToString().c_str()));
-        mnObj.push_back(Pair("notCapableReason", activeMasternode.notCapableReason.c_str()));
         return mnObj;
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -266,7 +266,8 @@ bool LogAcceptCategory(const char* category)
 
         // if not debugging everything and not debugging specific category, LogPrint does nothing.
         if (setCategories.count(string("")) == 0 &&
-            setCategories.count(string(category)) == 0)
+		setCategories.count(string("all")) == 0 &&
+            	setCategories.count(string(category)) == 0)
             return false;
     }
     return true;


### PR DESCRIPTION
- Output error messages in addition to error codes.
- Enable full debugging output by specifying '-debug=all' on the command line.
- Return statusMessage in addition to status code
- Unify messages and clean up